### PR TITLE
Remove jexec on BSD

### DIFF
--- a/make/modules/java.base/Launcher.gmk
+++ b/make/modules/java.base/Launcher.gmk
@@ -66,7 +66,7 @@ $(eval $(call SetupBuildLauncher, keytool, \
     MAIN_CLASS := sun.security.tools.keytool.Main, \
 ))
 
-ifeq ($(call isTargetOs, linux bsd), true)
+ifeq ($(call isTargetOs, linux), true)
   ##############################################################################
   ## Build jexec
   ##############################################################################


### PR DESCRIPTION
jexec traditionally has not been built on BSD since 1.8 and is headed for deprecated on linux:
https://bugs.openjdk.org/browse/JDK-8176066