### PR TITLE
Use getrusagelimit(2) for FreeBSD 14.2 and later

### DIFF
--- a/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
+++ b/src/jdk.management/bsd/native/libmanagement_ext/UnixOperatingSystem.c
@@ -190,7 +190,9 @@ JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getCommittedVirtualMemorySize0
   (JNIEnv *env, jobject mbean)
 {
-#if defined(__FreeBSD__) && __FreeBSD__ >= 15
+  // getrlimitusage(2) was introduced in FreeBSD 14.2 (even if the man
+  // page says FreeBSD 15.)
+#if defined(__FreeBSD__) && __FreeBSD_version >= 1402000
   rlim_t vmm_usage;
 
   int result = getrlimitusage(RLIMIT_AS, 0, &vmm_usage);
@@ -210,7 +212,9 @@ JNIEXPORT jlong JNICALL
 Java_com_sun_management_internal_OperatingSystemImpl_getOpenFileDescriptorCount0
   (JNIEnv *env, jobject mbean)
 {
-#if defined(__FreeBSD__) && __FreeBSD__ >= 15
+  // getrlimitusage(2) was introduced in FreeBSD 14.2 (even if the man
+  // page says FreeBSD 15.)
+#if defined(__FreeBSD__) && __FreeBSD_version >= 1402000
     rlim_t nfiles;
 
     int result = getrlimitusage(RLIMIT_NOFILE, 0, &nfiles);


### PR DESCRIPTION
The man page says the function is only available after FreeBSD 15, but they are in reality available since 14.2.

See:
https://cgit.freebsd.org/src/commit/?h=releng/14.2&id=7c41d08320a18634a32bba727dc5f9f78086e746 
https://cgit.freebsd.org/src/commit/?h=releng/14.2&id=dac3b7e394fdf98fdea05608e80f2b24f5ba8e9e

As the changes that introduced the use of getrusagelimit(2) was important for fixing some performance issues, limiting their use to only FreeBSD 15 or later will cause performance regressions for installations running the current production release of FreeBSD.

This work was sponsored by: The FreeBSD Foundation