### PR TITLE
8371637: allocateNativeInternal sometimes return incorrectly aligned …

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -212,7 +212,9 @@ public class SegmentFactories {
             allocationBase = allocateMemoryWrapper(allocationSize);
             result = Utils.alignUp(allocationBase, byteAlignment);
         } else {
-            allocationSize = alignedSize;
+            // always allocate at least 'byteAlignment' bytes, so that malloc is guaranteed to
+            // return a pointer aligned to that alignment, for cases where byteAlignment > alignedSize
+            allocationSize = Math.max(alignedSize, byteAlignment);
             if (shouldReserve) {
                 AbstractMemorySegmentImpl.NIO_ACCESS.reserveMemory(allocationSize, byteSize);
             }

--- a/test/jdk/java/foreign/TestMemoryAlignment.java
+++ b/test/jdk/java/foreign/TestMemoryAlignment.java
@@ -60,8 +60,14 @@ public class TestMemoryAlignment {
         assertEquals(aligned.byteAlignment(), align); //unreasonable alignment here, to make sure access throws
         VarHandle vh = aligned.varHandle();
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(aligned);;
+            MemorySegment segment = arena.allocate(aligned);
             vh.set(segment, 0L, -42);
+
+            // Allocate another segment and fill it with data to
+            // check that the first segment is not overwritten
+            MemorySegment nextSegment = arena.allocate(aligned);
+            vh.set(nextSegment, 0L, 0xffffff);
+
             int val = (int)vh.get(segment, 0L);
             assertEquals(val, -42);
         }


### PR DESCRIPTION
…memory

Backported for JDK 25 on BSD.

While this fix is scheduled for inclusion in JDK 26 by upatream, I think it's worth including in JDK 25 for BSD as it affects FreeBSD (and possibly NetBSD), and since JDK 25 is a LTS release. Waiting for the next LTS release for this fix seems a bit excessive.


Reviewed-by: mcimadamore, jvernee