### PR TITLE
Fix backport of runtime detection of HWCAPS and fix missing call to StubGenerator::generate_atomic_entry_points

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -10260,7 +10260,7 @@ class StubGenerator: public StubCodeGenerator {
     return start;
   }
 
-#if (defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)) || defined(_BSDONLY_SOURCE)
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
 
   // ARMv8.1 LSE versions of the atomic stubs used by Atomic::PlatformXX.
   //
@@ -11724,11 +11724,11 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
     StubRoutines::_upcall_stub_load_target = generate_upcall_stub_load_target();
 
-#if defined (LINUX) && !defined (__ARM_FEATURE_ATOMICS)
+#if (defined (LINUX) || defined(_BSDONLY_SOURCE)) && !defined (__ARM_FEATURE_ATOMICS)
 
     generate_atomic_entry_points();
 
-#endif // LINUX
+#endif // LINUX || _BSDONLY_SOURCE
 
 #ifdef COMPILER2
     if (UseSecondarySupersTable) {

--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -481,22 +481,22 @@ void VM_Version::get_os_cpu_info() {
   elf_aux_info(AT_HWCAP, &auxv, sizeof(auxv));
   elf_aux_info(AT_HWCAP2, &auxv2, sizeof(auxv2));
 
-  static_assert(BIT_MASK(CPU_FP)      == HWCAP_FP,      "Flag CPU_FP must follow HWCAP");
-  static_assert(BIT_MASK(CPU_ASIMD)   == HWCAP_ASIMD,   "Flag CPU_ASIMD must follow HWCAP");
-  static_assert(BIT_MASK(CPU_EVTSTRM) == HWCAP_EVTSTRM, "Flag CPU_EVTSTRM must follow HWCAP");
-  static_assert(BIT_MASK(CPU_AES)     == HWCAP_AES,     "Flag CPU_AES must follow HWCAP");
-  static_assert(BIT_MASK(CPU_PMULL)   == HWCAP_PMULL,   "Flag CPU_PMULL must follow HWCAP");
-  static_assert(BIT_MASK(CPU_SHA1)    == HWCAP_SHA1,    "Flag CPU_SHA1 must follow HWCAP");
-  static_assert(BIT_MASK(CPU_SHA2)    == HWCAP_SHA2,    "Flag CPU_SHA2 must follow HWCAP");
-  static_assert(BIT_MASK(CPU_CRC32)   == HWCAP_CRC32,   "Flag CPU_CRC32 must follow HWCAP");
-  static_assert(BIT_MASK(CPU_LSE)     == HWCAP_ATOMICS, "Flag CPU_LSE must follow HWCAP");
-  static_assert(BIT_MASK(CPU_DCPOP)   == HWCAP_DCPOP,   "Flag CPU_DCPOP must follow HWCAP");
-  static_assert(BIT_MASK(CPU_SHA3)    == HWCAP_SHA3,    "Flag CPU_SHA3 must follow HWCAP");
-  static_assert(BIT_MASK(CPU_SHA512)  == HWCAP_SHA512,  "Flag CPU_SHA512 must follow HWCAP");
-  static_assert(BIT_MASK(CPU_SVE)     == HWCAP_SVE,     "Flag CPU_SVE must follow HWCAP");
-  static_assert(BIT_MASK(CPU_PACA)    == HWCAP_PACA,    "Flag CPU_PACA must follow HWCAP");
-  static_assert(BIT_MASK(CPU_FPHP)    == HWCAP_FPHP,    "Flag CPU_FPHP must follow HWCAP");
-  static_assert(BIT_MASK(CPU_ASIMDHP) == HWCAP_ASIMDHP, "Flag CPU_ASIMDHP must follow HWCAP");
+  static_assert(CPU_FP      == HWCAP_FP,      "Flag CPU_FP must follow HWCAP");
+  static_assert(CPU_ASIMD   == HWCAP_ASIMD,   "Flag CPU_ASIMD must follow HWCAP");
+  static_assert(CPU_EVTSTRM == HWCAP_EVTSTRM, "Flag CPU_EVTSTRM must follow HWCAP");
+  static_assert(CPU_AES     == HWCAP_AES,     "Flag CPU_AES must follow HWCAP");
+  static_assert(CPU_PMULL   == HWCAP_PMULL,   "Flag CPU_PMULL must follow HWCAP");
+  static_assert(CPU_SHA1    == HWCAP_SHA1,    "Flag CPU_SHA1 must follow HWCAP");
+  static_assert(CPU_SHA2    == HWCAP_SHA2,    "Flag CPU_SHA2 must follow HWCAP");
+  static_assert(CPU_CRC32   == HWCAP_CRC32,   "Flag CPU_CRC32 must follow HWCAP");
+  static_assert(CPU_LSE     == HWCAP_ATOMICS, "Flag CPU_LSE must follow HWCAP");
+  static_assert(CPU_DCPOP   == HWCAP_DCPOP,   "Flag CPU_DCPOP must follow HWCAP");
+  static_assert(CPU_SHA3    == HWCAP_SHA3,    "Flag CPU_SHA3 must follow HWCAP");
+  static_assert(CPU_SHA512  == HWCAP_SHA512,  "Flag CPU_SHA512 must follow HWCAP");
+  static_assert(CPU_SVE     == HWCAP_SVE,     "Flag CPU_SVE must follow HWCAP");
+  static_assert(CPU_PACA    == HWCAP_PACA,    "Flag CPU_PACA must follow HWCAP");
+  static_assert(CPU_FPHP    == HWCAP_FPHP,    "Flag CPU_FPHP must follow HWCAP");
+  static_assert(CPU_ASIMDHP == HWCAP_ASIMDHP, "Flag CPU_ASIMDHP must follow HWCAP");
   _features = auxv & (
       HWCAP_FP      |
       HWCAP_ASIMD   |
@@ -511,19 +511,14 @@ void VM_Version::get_os_cpu_info() {
       HWCAP_SHA3    |
       HWCAP_SHA512  |
       HWCAP_SVE     |
-      HWCAP_SB      |
       HWCAP_PACA    |
       HWCAP_FPHP    |
       HWCAP_ASIMDHP);
 
   // Only allow SVE2 features if SVE is also available
   if (auxv & HWCAP_SVE) {
-    if (auxv2 & HWCAP2_SVE2) {
-      set_feature(CPU_SVE2);
-    }
-    if (auxv2 & HWCAP2_SVEBITPERM) {
-      set_feature(CPU_SVEBITPERM);
-    }
+    if (auxv2 & HWCAP2_SVE2) _features |= CPU_SVE2;
+    if (auxv2 & HWCAP2_SVEBITPERM) _features |= CPU_SVEBITPERM;
   }
 
   /*


### PR DESCRIPTION
The back porting of runtime detection of HWCAPS can't be cherry-picked as there are differences in the list of HWCAPs that each older version of the jdk supports and some slight code differences as well.  In OpenBSD ports I have already backported it to [25u](https://github.com/openbsd/ports/blob/master/devel/jdk/25/patches/patch-src_hotspot_os_cpu_bsd_aarch64_vm_version_bsd_aarch64_cpp) [21u](https://github.com/openbsd/ports/blob/master/devel/jdk/21/patches/patch-src_hotspot_os_cpu_bsd_aarch64_vm_version_bsd_aarch64_cpp) [17u](https://github.com/openbsd/ports/blob/master/devel/jdk/17/patches/patch-src_hotspot_os_cpu_bsd_aarch64_vm_version_bsd_aarch64_cpp) and [11u](https://github.com/openbsd/ports/blob/master/devel/jdk/11/patches/patch-src_hotspot_os_cpu_bsd_aarch64_vm_version_bsd_aarch64_cpp). In each back port I synced the slight code differences and sync'ed the list of detected HWCAPS to the linux version of this file.

This PR fixes the build on aarch64 by syncing the runtime detection of HWCAPS and includes the fix for the missing call to  StubGenerator::generate_atomic_entry_points()