### PR TITLE
Revert "Sync constructors for ThreadWXEnable with MacOS impl"

### DIFF
--- a/src/hotspot/share/runtime/threadWXSetters.inline.hpp
+++ b/src/hotspot/share/runtime/threadWXSetters.inline.hpp
@@ -83,8 +83,8 @@ public:
 class ThreadWXEnable  {
   WXMode _new_mode;
 public:
-  ThreadWXEnable(WXMode * new_mode, Thread*) :
-    _new_mode(*new_mode)
+  ThreadWXEnable(WXMode new_mode, Thread*) :
+    _new_mode(new_mode)
   {
     if (_new_mode == WXExec) {
       // We are going to execute some code that has been potentially
@@ -93,12 +93,6 @@ public:
                             "isb\tsy" : : : "memory");
     }
   }
-
-  ThreadWXEnable(WXMode new_mode, Thread * t)
-  {
-    ThreadWXEnable(&new_mode, t);
-  }
-
   ~ThreadWXEnable() {
     if (_new_mode == WXWrite) {
       // We may have modified some code that is going to be executed


### PR DESCRIPTION
This reverts commit e92e6b5bc451cfc129679df536ae880224580fb1.

This fixes building jdk25 on Aarch64.

This work is sponsored by The FreeBSD Foundation