### PR TITLE
GHA: Some BSD GHA Changes

### DIFF
--- a/.github/actions/do-build-vm/action.yml
+++ b/.github/actions/do-build-vm/action.yml
@@ -75,7 +75,7 @@ runs:
       shell: bash
 
     - name: 'Upload build logs'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: failure-logs-${{ inputs.platform }}${{ inputs.debug-suffix }}
         path: failure-logs
@@ -83,7 +83,7 @@ runs:
 
       # This is the best way I found to abort the job with an error message
     - name: 'Notify about build failures'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: core.setFailed('Build failed. See summary for details.')
       if: steps.check.outputs.failure == 'true'

--- a/.github/workflows/build-openbsd.yml
+++ b/.github/workflows/build-openbsd.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: 'Restore Cached VM Packages'
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -184,7 +184,7 @@ jobs:
           sudo df -h
 
       - name: 'Save VM Packages'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -392,7 +392,7 @@ jobs:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
       vm-arch: 'x86_64'
-      vm-release: "7.8"
+      vm-release: "7.9"
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.prepare.outputs.openbsd-x64 == 'true'
@@ -481,7 +481,7 @@ jobs:
     with:
       platform: openbsd-x64
       runs-on: ubuntu-24.04
-      vm-release: 7.8
+      vm-release: 7.9
       vm-arch: x86_64
       debug-suffix: -debug
 

--- a/.github/workflows/test-freebsd.yml
+++ b/.github/workflows/test-freebsd.yml
@@ -240,7 +240,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -248,7 +248,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -78,7 +78,6 @@ jobs:
         include:
           - test-name: 'jdk/tier1 part 1'
             test-suite: 'test/jdk/:tier1_part1'
-            test-timeout-factor: 'TIMEOUT_FACTOR=4'
 
           - test-name: 'jdk/tier1 part 2'
             test-suite: 'test/jdk/:tier1_part2'
@@ -115,7 +114,6 @@ jobs:
 
           - test-name: 'hs/tier1 serviceability'
             test-suite: 'test/hotspot/jtreg/:tier1_serviceability'
-            test-timeout-factor: 'TIMEOUT_FACTOR=2'
             debug-suffix: ${{ inputs.debug-suffix }}
 
           - test-name: 'lib-test/tier1'
@@ -202,7 +200,6 @@ jobs:
           run: >
             ulimit -Sd $(ulimit -dH) &&
             gmake test-prebuilt
-            TEST_JOBS=1
             TEST='${{ matrix.test-suite }}'
             BOOT_JDK=${{ steps.bootjdk.outputs.path }}
             JT_HOME=${{ steps.jtreg.outputs.path }}
@@ -211,7 +208,7 @@ jobs:
             TEST_IMAGE_DIR=${{ steps.bundles.outputs.tests-path }}
             ${{ steps.extra-options.outputs.test-jdk }}
             ${{ steps.extra-options.outputs.compile-jdk }}
-            JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful;${{ steps.extra-options.outputs.extra-problem-lists }};${{ matrix.test-timeout-factor }}'
+            JTREG='JAVA_OPTIONS=-XX:-CreateCoredumpOnCrash;VERBOSE=fail,error,time;KEYWORDS=!headful;${{ steps.extra-options.outputs.extra-problem-lists }}'
             && bash ./.github/scripts/gen-test-summary.sh "$GITHUB_STEP_SUMMARY" "$GITHUB_OUTPUT"
 
       - name: 'Check Memory, Swap and Disk Usage'

--- a/.github/workflows/test-openbsd.yml
+++ b/.github/workflows/test-openbsd.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Restore Cached VM Packages
         id: vm-packages-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: obsd-pkg-cache
           key: packages-${{ inputs.platform }}-${{ inputs.vm-release }}-${{ inputs.vm-arch }}-${{ hashFiles('./obsd-pkg-cache/*.tgz') }}
@@ -252,7 +252,7 @@ jobs:
         if: always()
 
       - name: 'Upload test results'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: results
           name: ${{ steps.package.outputs.artifact-name }}
@@ -260,7 +260,7 @@ jobs:
 
         # This is the best way I found to abort the job with an error message
       - name: 'Notify about test failures'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: core.setFailed('${{ steps.run-tests.outputs.error-message }}')
         if: steps.run-tests.outputs.failure == 'true'

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
@@ -53,8 +53,8 @@ public class GetStackTraceALotWhenBlocking {
 
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX()) {
-            // reduced iterations on macosx
+        if (Platform.isOSX() || Platform.isOpenBSD()) {
+            // reduced iterations on macosx and openbsd
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -56,8 +56,8 @@ public class GetStackTraceALotWhenPinned {
 
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX()) {
-            // reduced iterations on macosx
+        if (Platform.isOSX() || Platform.isOpenBSD()) {
+            // reduced iterations on macosx and openbsd
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;

--- a/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
@@ -49,8 +49,8 @@ public class ParkALot {
     public static void main(String[] args) throws Exception {
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX()) {
-            // reduced iterations on macosx
+        if (Platform.isOSX() || Platform.isOpenBSD()) {
+            // reduced iterations on macosx and openbsd
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;


### PR DESCRIPTION
Use OpenBSD 7.9 for build and testing
Remove OpenBSD test work-arounds
Backport: Reduce iterations on these tests for OpenBSD Similar to OSX
Fix remaining Node 20 uses