### PR TITLE
Fix building with clang 22

### DIFF
--- a/src/hotspot/share/oops/resolvedFieldEntry.cpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.cpp
@@ -46,7 +46,7 @@ void ResolvedFieldEntry::print_on(outputStream* st) const {
 #if INCLUDE_CDS
 void ResolvedFieldEntry::remove_unshareable_info() {
   u2 saved_cpool_index = _cpool_index;
-  memset(this, 0, sizeof(*this));
+  memset((void *)this, 0, sizeof(*this));
   _cpool_index = saved_cpool_index;
 }
 

--- a/src/hotspot/share/oops/resolvedMethodEntry.cpp
+++ b/src/hotspot/share/oops/resolvedMethodEntry.cpp
@@ -40,12 +40,12 @@ void ResolvedMethodEntry::reset_entry() {
   if (has_resolved_references_index()) {
     u2 saved_resolved_references_index = _entry_specific._resolved_references_index;
     u2 saved_cpool_index = _cpool_index;
-    memset(this, 0, sizeof(*this));
+    memset((void *)this, 0, sizeof(*this));
     set_resolved_references_index(saved_resolved_references_index);
     _cpool_index = saved_cpool_index;
   } else {
     u2 saved_cpool_index = _cpool_index;
-    memset(this, 0, sizeof(*this));
+    memset((void *)this, 0, sizeof(*this));
     _cpool_index = saved_cpool_index;
   }
 }

--- a/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
+++ b/src/java.desktop/unix/native/libawt_xawt/java2d/x11/XRBackendNative.c
@@ -339,7 +339,7 @@ Java_sun_java2d_xr_XRBackendNative_createPixmap(JNIEnv *env, jobject this,
 JNIEXPORT jint JNICALL
 Java_sun_java2d_xr_XRBackendNative_createPictureNative
  (JNIEnv *env, jclass cls, jint drawable, jlong formatPtr) {
-  XRenderPictureAttributes pict_attr;
+  XRenderPictureAttributes pict_attr = { 0 };
   return XRenderCreatePicture(awt_display, (Drawable) drawable,
                               (XRenderPictFormat *) jlong_to_ptr(formatPtr),
                                0, &pict_attr);


### PR DESCRIPTION
OpenBSD porting team is preparing for using clang 22 in the future and made a pass at building all ports with it. It found a couple of warnings but the build of hotspot has warnings are errors by default. Upstream fixed both of these in openjdk/jdk already:

https://github.com/bsdkurt/jdk/commit/0dd5b59194f32f54c2ec6572833f45e1402515ba
https://github.com/bsdkurt/jdk/commit/66fb015267058f9b5e6788eaeaa758be56ba553e

However, for the memset warning/errors, upstream opted for a more involved solution. Instead of back-porting the more involved fixes for the warning, I went with the simple cast here.